### PR TITLE
Feature: Parse variable in control node value

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -6,6 +6,11 @@ module.exports = {
 		await this.SingularLive.animateOut(comp)
 	},
 	async updateControlNode({ controlnode, value }) {
+		if (value.includes('$(')) {
+			system.emit('variable_parse', value, function (str) {
+				value = str.trim()
+			})
+		}
 		await this.SingularLive.updateControlNode(controlnode, value)
 	},
 	async updateButtonNode({ controlnode }) {


### PR DESCRIPTION
Resolves #1754

Allows/parses Companion variables to be used within the Control Node action Value option.

![image](https://user-images.githubusercontent.com/5514878/137269773-9dc97c31-54b0-4c47-93e5-33af2bf6436f.png)

Signed-off-by: Johnny Estilles <johnny@estilles.com>