### PR TITLE
Feature: Update control nodes on root composition

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ class SingularInstance extends InstanceBase {
 									} else if (node.type == 'selection') {
 										selections.push({
 											...controlNode,
-											selections: node.selections.map((selection) => ({
+											selections: node.selections?.map((selection) => ({
 												id: selection.id,
 												label: selection.title,
 											})),
@@ -110,7 +110,8 @@ class SingularInstance extends InstanceBase {
 					}
 				})
 				.catch((err) => {
-					this.log('warn', err)
+					this.log('debug', err)
+					this.log('warn', err.toString())
 					throw new Error(err)
 				})
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -37,6 +37,7 @@ export default class SingularLive {
 				[entry[1].title]: {
 					id: entry[1].id,
 					type: entry[1].type,
+					...(entry[1].selections) && {selections: entry[1].selections},
 				},
 			}
 		})

--- a/lib/api.js
+++ b/lib/api.js
@@ -3,6 +3,9 @@ import fetch from 'node-fetch'
 const url = 'https://app.singular.live/apiv2/controlapps/'
 
 export default class SingularLive {
+	rootCompName = 'Root Composition'
+	rootCompId = undefined
+
 	constructor(apiurl) {
 		if (apiurl && apiurl.includes('/')) {
 			let urlparts = apiurl.split('/')
@@ -28,29 +31,36 @@ export default class SingularLive {
 		})
 	}
 
+	getNodes(model) {
+		return Object.entries(model).map((entry) => {
+			return {
+				[entry[1].title]: {
+					id: entry[1].id,
+					type: entry[1].type,
+				},
+			}
+		})
+	}
+
 	getElements() {
 		return new Promise((resolve, reject) => {
 			fetch(url + this.token + '/model', this.GETOption())
 				.then((res) => res.json())
 				.then((result) => {
+					this.rootCompId = result[0].id
 					let data = result[0].subcompositions
-					const elements = []
+					const elements = [
+						{
+							id: result[0].id,
+							name: this.rootCompName,
+							nodes: result[0].model ? this.getNodes(result[0].model) : [],
+						},
+					]
 					for (let i = 0; i < data.length; i++) {
 						let element = {
 							id: data[i].id,
 							name: data[i].name,
-							nodes: [],
-						}
-
-						if (data[i].model) {
-							element.nodes = Object.entries(data[i].model).map((entry) => {
-								return {
-									[entry[1].title]: {
-										id: entry[1].id,
-										type: entry[1].type,
-									},
-								}
-							})
+							nodes: data[i].model ? this.getNodes(data[i].model) : [],
 						}
 
 						elements.push(element)
@@ -61,27 +71,29 @@ export default class SingularLive {
 		})
 	}
 
+	/**
+	 * The returned name for the root composition from the /model api root is incorrect.
+	 *
+	 * To workaround, we store a label and the root composition id on this class
+	 * This function returns the correct key/value to target the composition based on its name
+	 */
+	subcompIdentifier(composition) {
+		return composition === this.rootCompName
+			? { subCompositionId: this.rootCompId }
+			: { subCompositionName: composition }
+	}
+
 	animateIn(composition) {
 		if (!composition) return
 
-		const body = [
-			{
-				subCompositionName: composition,
-				state: 'In',
-			},
-		]
+		const body = [{ ...this.subcompIdentifier(composition), state: 'In' }]
 		fetch(url + this.token + '/control', this.PATCHOption(body))
 	}
 
 	animateOut(composition) {
 		if (!composition) return
 
-		const body = [
-			{
-				subCompositionName: composition,
-				state: 'Out',
-			},
-		]
+		const body = [{ ...this.subcompIdentifier(composition), state: 'Out' }]
 
 		fetch(url + this.token + '/control', this.PATCHOption(body))
 	}
@@ -91,7 +103,7 @@ export default class SingularLive {
 
 		const body = [
 			{
-				subCompositionName: controlnode.split('&!&!&')[0],
+				...this.subcompIdentifier(controlnode.split('&!&!&')[0]),
 				payload: {
 					[controlnode.split('&!&!&')[1]]: value,
 				},
@@ -106,7 +118,7 @@ export default class SingularLive {
 
 		const body = [
 			{
-				subCompositionName: controlnode.split('&!&!&')[0],
+				...this.subcompIdentifier(controlnode.split('&!&!&')[0]),
 				payload: {
 					[controlnode.split('&!&!&')[1]]: 'execute',
 				},
@@ -121,7 +133,7 @@ export default class SingularLive {
 
 		const body = [
 			{
-				subCompositionName: controlnode.split('&!&!&')[0],
+				...this.subcompIdentifier(controlnode.split('&!&!&')[0]),
 				payload: {
 					[controlnode.split('&!&!&')[1]]: value,
 				},
@@ -136,7 +148,7 @@ export default class SingularLive {
 
 		const body = [
 			{
-				subCompositionName: controlnode.split('&!&!&')[0],
+				...this.subcompIdentifier(controlnode.split('&!&!&')[0]),
 				payload: {
 					[controlnode.split('&!&!&')[1]]: {
 						command: value,


### PR DESCRIPTION
This adds the root composition to the list of elements returned from `getElements`.

Note: We have to workaround an incorrect name for the root compositon returned from the `https://app.singular.live/apiv2/controlapps/<TOKEN>/model` (and in the process, provide a nicer label than the correct `mainComposition` which could alternatively be used)