### PR TITLE
Handle selection node type

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,4 @@
-export function getActions(compositions, controlnodes, buttons, checkboxes, timers) {
+export function getActions(compositions, controlnodes, buttons, checkboxes, timers, selections) {
 	return {
 		animateIn: {
 			name: 'Animate In',
@@ -120,6 +120,33 @@ export function getActions(compositions, controlnodes, buttons, checkboxes, time
 			],
 			callback: async (action) => {
 				await this.SingularLive.updateTimer(action.options.controlnode, action.options.value)
+			},
+		},
+		updateSelectionNode: {
+			name: 'Update Selection Node',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Control Node',
+					id: 'controlnode',
+					choices: selections,
+					default: selections?.[0]?.id,
+					allowCustom: false,
+				},
+				...selections.map((selection) => ({
+					type: 'dropdown',
+					label: 'Selection',
+					id: selection.id,
+					choices: selection.selections,
+					default: selection.selections?.[0]?.id,
+					isVisible: new Function('options', `return options.controlnode == '${selection.id}'`),
+				})),
+			],
+			callback: async (action) => {
+				await this.SingularLive.updateControlNode(
+					action.options.controlnode,
+					action.options[action.options.controlnode]
+				)
 			},
 		},
 		takeOutAllOutput: {

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ class SingularInstance extends InstanceBase {
 			const buttons = []
 			const checkboxes = []
 			const timers = []
+			const selections = []
 
 			await this.SingularLive.getElements()
 				.then((res) => {
@@ -94,6 +95,14 @@ class SingularInstance extends InstanceBase {
 										timers.push(controlNode)
 									} else if (node.type == 'checkbox') {
 										checkboxes.push(controlNode)
+									} else if (node.type == 'selection') {
+										selections.push({
+											...controlNode,
+											selections: node.selections.map((selection) => ({
+												id: selection.id,
+												label: selection.title,
+											})),
+										})
 									}
 								}
 							}
@@ -105,7 +114,9 @@ class SingularInstance extends InstanceBase {
 					throw new Error(err)
 				})
 
-			this.setActionDefinitions(getActions.bind(this)(compositions, controlnodes, buttons, checkboxes, timers))
+			this.setActionDefinitions(
+				getActions.bind(this)(compositions, controlnodes, buttons, checkboxes, timers, selections)
+			)
 
 			this.updateStatus('ok')
 		} catch (e) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -48,6 +48,7 @@ export default class SingularLive {
 									[entry[1].title]: {
 										id: entry[1].id,
 										type: entry[1].type,
+										selections: entry[1].selections,
 									},
 								}
 							})


### PR DESCRIPTION
Add a new action to allow updating selection/dropdown control nodes.

All selection nodes are collected together and provided as the first `option` inside the action.
On selecting that, a 2nd dropdown is made visible which provides only selections belonging to that control node